### PR TITLE
Fixed keyring access in Windows

### DIFF
--- a/src/kube/rancher.rs
+++ b/src/kube/rancher.rs
@@ -40,7 +40,11 @@ pub async fn get_rancher_kubeconfig(
 }
 
 pub fn get_rancher_token() -> eyre::Result<String> {
-    let entry = Entry::new(kubernetes::KEYRING_SERVICE_ID, kubernetes::KEYRING_KEY)?;
+    let entry = Entry::new_with_target(
+        kubernetes::KEYRING_SERVICE_ID,
+        kubernetes::KEYRING_SERVICE_ID,
+        kubernetes::KEYRING_KEY,
+    )?;
 
     Ok(entry.get_password()?)
 }

--- a/src/kube/rancher.rs
+++ b/src/kube/rancher.rs
@@ -39,6 +39,14 @@ pub async fn get_rancher_kubeconfig(
     Ok(kubeconfig)
 }
 
+#[cfg(target_family = "unix")]
+pub fn get_rancher_token() -> eyre::Result<String> {
+    let entry = Entry::new(kubernetes::KEYRING_SERVICE_ID, kubernetes::KEYRING_KEY)?;
+
+    Ok(entry.get_password()?)
+}
+
+#[cfg(target_family = "windows")]
 pub fn get_rancher_token() -> eyre::Result<String> {
     let entry = Entry::new_with_target(
         kubernetes::KEYRING_SERVICE_ID,


### PR DESCRIPTION
**Changes**
- Added a second implementation for Windows, which has to override the target
   - On Windows the target is not used to select the proper credential store, instead it is used to control the service alias
- Two implementations with `#[cfg(target_family = "unix")]` and `#[cfg(target_family = "windows")]`

**Tested**
- Tested under MacOS and Windows 11 
- Existing rancher tokens could be read successfully

**Testing**
- Linux with a properly set up credential store and existing token

**Remarks**
The plugin keeps in status `beta` as long as the features for adding a new token and a new kubeconfig is missing. Otherwise, the plugin is only usable for existing DG users with an already working environment.