### PR TITLE
Implemented kube init & doctor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2359,7 @@ dependencies = [
  "keyring",
  "lazy_static",
  "log",
+ "open",
  "rancher",
  "regex",
  "reqwest",
@@ -2363,6 +2383,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2c909a3fce3bd80efef4cd1c6c056bd9376a8fe06fcfdbebaf32cb485a7e37"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "openssl"
@@ -2511,6 +2542,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ json_to_table = "0.7.0"
 keyring = "2.3.3"
 lazy_static = "1.5.0"
 log = "0.4.22"
+open = "5.2.0"
 rancher = { git = "https://github.com/dannyyy/rancher-rs.git" }
 regex = "1.10.5"
 reqwest = { version = "0.12.5", default-features = false, features = [

--- a/src/kube/doctor.rs
+++ b/src/kube/doctor.rs
@@ -1,10 +1,11 @@
 use colored::Colorize;
 use eyre::Result;
+use log::info;
 use std::path::Path;
 
 use super::{
-    kube_config::{get_kubeconfig_path, read_kubeconfig},
-    rancher::get_rancher_token,
+    kube_config::{create_empty_kubeconfig, get_kubeconfig_path, read_kubeconfig},
+    rancher::{add_rancher_token, get_rancher_token},
     KubernetesPlugin,
 };
 use crate::{
@@ -30,7 +31,10 @@ impl KubernetesPlugin {
                 "No existing kubeconfig has been found. Please add a valid kubeconfig".red()
             ),
             plugin: PLUGIN_NAME.to_string(),
-            fix: None,
+            fix: Some(Box::new(|| {
+                create_empty_kubeconfig(true)
+                    .map_err(|_| format!("{}", "Unable to create a new empty kubeconfig!".red()))
+            })),
         })
     }
 
@@ -43,7 +47,11 @@ impl KubernetesPlugin {
                     error.to_string().yellow()
                 ),
                 plugin: PLUGIN_NAME.to_string(),
-                fix: None,
+                fix: Some(Box::new(|| {
+                    create_empty_kubeconfig(true).map_err(|_| {
+                        format!("{}", "Unable to create a new empty kubeconfig!".red())
+                    })
+                })),
             });
         }
 
@@ -54,6 +62,8 @@ impl KubernetesPlugin {
     }
 
     fn is_rancher_token_available() -> Result<DoctorSuccess, DoctorFailure> {
+        print_credential_store_warning();
+
         if let Err(error) = get_rancher_token() {
             return Err(DoctorFailure {
                 message: format!(
@@ -62,7 +72,10 @@ impl KubernetesPlugin {
                     error.to_string().yellow()
                 ),
                 plugin: PLUGIN_NAME.to_string(),
-                fix: None,
+                fix: Some(Box::new(|| {
+                    add_rancher_token()
+                        .map_err(|_| format!("{}", "Unable to add new Rancher API token!".red()))
+                })),
             });
         }
 
@@ -81,4 +94,8 @@ impl Plugin for KubernetesPlugin {
             Self::is_rancher_token_available(),
         ]
     }
+}
+
+fn print_credential_store_warning() {
+    info!("Depending on your OS, you have to confirm or enter your password to access the credential store to retrieve the necessary access tokens\n");
 }

--- a/src/kube/doctor.rs
+++ b/src/kube/doctor.rs
@@ -86,15 +86,18 @@ impl Plugin for KubernetesPlugin {
     }
 }
 
+// static mut NEW_KUBECONFIG_FIX_APPLIED: bool = false;
 fn apply_kubeconfig_fix() -> Result<(), String> {
-    // if self.new_kubeconfig_fix_applied {
+    // if NEW_KUBECONFIG_FIX_APPLIED {
     //     return Ok(());
     // }
 
     create_empty_kubeconfig(true)
-        .map_err(|_| format!("{}", "Unable to create a new empty kubeconfig!".red()))
+        .map_err(|_| format!("{}", "Unable to create a new empty kubeconfig!".red()))?;
 
-    // self.new_kubeconfig_fix_applied = true;
+    // NEW_KUBECONFIG_FIX_APPLIED = true;
+
+    Ok(())
 }
 
 fn apply_rancher_token_fix() -> Result<(), String> {

--- a/src/kube/kube_config.rs
+++ b/src/kube/kube_config.rs
@@ -1,5 +1,7 @@
-use eyre::{Context, ContextCompat, Result};
+use colored::Colorize;
+use eyre::{Context, ContextCompat, Ok, Result};
 use homedir::get_my_home;
+use log::info;
 use serde::{Deserialize, Serialize};
 use serde_yaml::{self, Value};
 use std::{fs, path::PathBuf, time::SystemTime};
@@ -89,8 +91,17 @@ pub fn write_kubeconfig(kube_config: KubeConfig, backup: bool) -> Result<()> {
     let updated_kube_config_content = serde_yaml::to_string(&kube_config)?;
     let kubeconfig_path = get_kubeconfig_path()?;
 
-    if backup {
+    if backup && kubeconfig_path.path.exists() {
         fs::copy(&kubeconfig_path.path, &kubeconfig_path.backup_path)?;
+        info!(
+            "Created a backup of the existing kubeconfig: {}",
+            kubeconfig_path
+                .backup_path
+                .as_path()
+                .to_str()
+                .unwrap()
+                .cyan()
+        );
     }
 
     // Write the updated config back to the file
@@ -114,4 +125,21 @@ pub fn get_kubeconfig_path() -> Result<KubeconfigPath> {
         .join(format!(".kube/config.bak-{}", timestamp));
 
     Ok(KubeconfigPath { path, backup_path })
+}
+
+pub fn create_empty_kubeconfig(kubeconfig_backup: bool) -> Result<()> {
+    let empty_kubeconfig = KubeConfig {
+        kind: "Config".to_string(),
+        api_version: "v1".to_string(),
+        current_context: "".to_string(),
+        preferences: None,
+        clusters: Vec::new(),
+        contexts: Vec::new(),
+        users: Vec::new(),
+    };
+
+    write_kubeconfig(empty_kubeconfig, kubeconfig_backup)?;
+
+    info!("{}", "A new kubeconfig has been created\n".green());
+    Ok(())
 }

--- a/src/kube/kubernetes.rs
+++ b/src/kube/kubernetes.rs
@@ -446,7 +446,10 @@ async fn update_kubeconfig_entry(
     Ok(())
 }
 
-fn delete_kubeconfig_entry(kubeconfig: &mut KubeConfig, local_cluster: &Cluster) -> eyre::Result<()> {
+fn delete_kubeconfig_entry(
+    kubeconfig: &mut KubeConfig,
+    local_cluster: &Cluster,
+) -> eyre::Result<()> {
     kubeconfig
         .clusters
         .retain(|c| c.name != get_cluster_fullname(local_cluster));

--- a/src/kube/rancher.rs
+++ b/src/kube/rancher.rs
@@ -1,8 +1,12 @@
+use colored::Colorize;
+use dialoguer::Select;
 use eyre::eyre;
 use keyring::Entry;
+use log::info;
 use rancher::RancherClient;
 use reqwest::{Client, Url};
 use serde::Deserialize;
+use std::ffi::OsStr;
 
 use super::{
     kubernetes::{self, Cluster},
@@ -88,4 +92,43 @@ pub async fn get_rancher_clusters(rancher_token: &str) -> Vec<Cluster> {
     }
 
     Vec::new()
+}
+
+pub fn add_rancher_token() -> eyre::Result<()> {
+    let selected_option = Select::new()
+        .with_prompt("Would you like to create a new Rancher API token or use an existing one")
+        .default(0)
+        .items(&["New Token", "Existing Token"])
+        .interact()
+        .unwrap();
+
+    match selected_option {
+        0 => create_new_rancher_token()?,
+        1 => add_existing_rancher_token()?,
+        _ => unimplemented!(),
+    };
+
+    Ok(())
+}
+
+fn create_new_rancher_token() -> eyre::Result<()> {
+    let mut rancher_url = get_config().rancher_base_url.clone();
+    rancher_url.push_str("/dashboard/account/create-key");
+
+    info!("Use these options to create a new Rancher API token:");
+    info!("1. Open {}", &rancher_url);
+    info!("2. Create a new Rancher API token");
+    info!("\t{}:\t\t{}", "Description".cyan(), "OG-CLI");
+    info!("\t{}:\t\t\t{}", "Scope".cyan(), "No Scope");
+    info!("\t{}:\t{}", "Automatically expire".cyan(), "Never");
+
+    open::that(OsStr::new(&rancher_url))?;
+
+    add_existing_rancher_token()?;
+
+    Ok(())
+}
+
+fn add_existing_rancher_token() -> eyre::Result<()> {
+    Ok(())
 }

--- a/src/kube/rancher.rs
+++ b/src/kube/rancher.rs
@@ -152,19 +152,19 @@ fn add_existing_rancher_token() -> eyre::Result<()> {
 }
 
 #[cfg(target_family = "unix")]
-pub fn set_rancher_token(token: &String) -> eyre::Result<()> {
+pub fn set_rancher_token(token: &str) -> eyre::Result<()> {
     let entry = Entry::new(kubernetes::KEYRING_SERVICE_ID, kubernetes::KEYRING_KEY)?;
 
     Ok(entry.set_password(token)?)
 }
 
 #[cfg(target_family = "windows")]
-pub fn set_rancher_token(token: &String) -> eyre::Result<()> {
+pub fn set_rancher_token(token: &str) -> eyre::Result<()> {
     let entry = Entry::new_with_target(
         kubernetes::KEYRING_SERVICE_ID,
         kubernetes::KEYRING_SERVICE_ID,
         kubernetes::KEYRING_KEY,
     )?;
 
-    Ok(entry.set_password(token1)?)
+    Ok(entry.set_password(token)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ enum Commands {
     Fix(FixCommand),
     #[clap(name = "dotnet")]
     Dotnet(DotnetCommand),
-    #[clap(name = "kube-beta")]
+    #[clap(name = "kube")]
     Kubernetes(KubernetesCommand),
     #[cfg(feature = "git")]
     #[clap(name = "git-beta")]


### PR DESCRIPTION
**Changes**
- Implemented `kube init` which allows to
   - Add or update a Rancher API token
   - Create a new empty kubeconfig (if the config is not existing or with a backup if corrupt)
<img width="958" alt="image" src="https://github.com/tkaepp/og-cli/assets/3018863/d0619688-b193-419a-8fd3-f56364fca7aa">

- Implanted `doctor --apply-fixes` for the `kube` plugin
   - Can fix kubeconfig issues
   - Can fix Rancher API token issues
<img width="957" alt="image" src="https://github.com/tkaepp/og-cli/assets/3018863/aab5f3ea-a415-4b71-9617-0085dd8a490e">
<img width="956" alt="image" src="https://github.com/tkaepp/og-cli/assets/3018863/afb179b5-ee91-4f81-9fa6-14382bf01f3d">


- Promoted plugin to `kube` (from beta)